### PR TITLE
Make it possible to depend on haskell_libraries from statically linked cc targets

### DIFF
--- a/bzl/def.bzl
+++ b/bzl/def.bzl
@@ -29,6 +29,7 @@ load(
     _haskell_library = "haskell_library",
     _haskell_proto_aspect = "haskell_proto_aspect",
     _haskell_proto_library = "haskell_proto_library",
+    _haskell_static_foreign_library = "haskell_static_foreign_library",
 )
 
 haskell_binary = _haskell_binary
@@ -38,3 +39,4 @@ haskell_library = _haskell_library
 haskell_proto_aspect = _haskell_proto_aspect
 haskell_proto_library = _haskell_proto_library
 haskell_test = _haskell_test
+haskell_static_foreign_library = _haskell_static_foreign_library

--- a/bzl/private/BUILD
+++ b/bzl/private/BUILD
@@ -1,5 +1,6 @@
 # Internal functions for the Haskell build rules.
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
 
 package(default_visibility = ["//bzl:__subpackages__"])
 
@@ -33,4 +34,10 @@ bzl_library(
         "//bzl/private/builddata:builddata.bzl",
         "@bazel_tools//tools/cpp:toolchain_utils",
     ],
+)
+
+bool_setting(
+    name = "bundle_cc_deps",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
 )

--- a/bzl/private/BUILD
+++ b/bzl/private/BUILD
@@ -23,12 +23,14 @@ bzl_library(
         "providers.bzl",
         "runfiles.bzl",
         "toolchains.bzl",
-        "@bazel_tools//tools/build_defs/cc:action_names.bzl",
-        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     ],
     deps = [
         "@bazel_skylib//lib:paths",
+        "@bazel_tools//tools/build_defs/cc:action_names",
+        "@bazel_tools//tools/build_defs/cc/contrib:cc_lto_backend",
         "//bzl:paths",
         "//bzl:settings",
+        "//bzl/private/builddata:builddata.bzl",
+        "@bazel_tools//tools/cpp:toolchain_utils",
     ],
 )

--- a/bzl/private/archive.bzl
+++ b/bzl/private/archive.bzl
@@ -111,7 +111,7 @@ def create_shared_haskell_lib(ctx, toolchains, archive_name, lib, collected_deps
 
     Args:
       ctx: The current rule context
-      toolchains: A struct as returned by def.bzl:_get_toolchains.
+      toolchains: A struct as returned by def.bzl:get_toolchains.
       archive_name: The name of the output archive, minus the "lib"
         prefix and ".a" suffix.
       lib: The compiled library.
@@ -127,7 +127,8 @@ def create_shared_haskell_lib(ctx, toolchains, archive_name, lib, collected_deps
         is_linking_dynamic_library = True,
     )
 
-    # TODO: do we need to also include the version number when it's nontrivial?
+    # GHC expects the compiler version suffix in the .so file name.
+    # https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/packages.html#building-a-package-from-haskell-source
     shared_lib = ctx.actions.declare_file("{}/lib{}-ghc{}.so".format(
         package.libdir(ctx),
         archive_name,

--- a/bzl/private/archive.bzl
+++ b/bzl/private/archive.bzl
@@ -14,6 +14,7 @@
 
 """Functions for creating static and dynamic shared libraries."""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:collections.bzl", "collections")
 load("//bzl/private:action.bzl", "multi_action")
 load(
@@ -106,7 +107,7 @@ def _shared_linker_args(output_lib, libs, runtime_libs = []):
         ["-Wl,-rpath," + origin_rpath_prefix + d for d in dynamic_lib_dirs]
     )
 
-def create_shared_haskell_lib(ctx, toolchains, archive_name, lib, collected_deps):
+def create_shared_haskell_lib(ctx, toolchains, archive_name, lib, collected_deps, bundle_cc_deps):
     """Links the Haskell-built *.dyn_o objects together into a shared library.
 
     Args:
@@ -118,7 +119,9 @@ def create_shared_haskell_lib(ctx, toolchains, archive_name, lib, collected_deps
       collected_deps: A struct of dependencies of this target.
 
     Returns:
-      A File for the resulting "*.so" library.
+      A pair of File objects. First one is the resulting "*.so" Haskell library,
+      while the second is a LibraryToLink representing a cc dynamic library that
+      links against all cc dependencies of the Haskell target.
     """
     config = toolchains.haskell
     ld = link_executable_command(
@@ -134,6 +137,37 @@ def create_shared_haskell_lib(ctx, toolchains, archive_name, lib, collected_deps
         archive_name,
         config.version,
     ))
+
+    if bundle_cc_deps:
+        # Bundle all CC deps into a self-contained dynamic shared library. It
+        # will remain dynamic even when the library will get linked into a
+        # mostly-statically linked executable, and will then be copied into
+        # the .runfiles directory along with the Haskell shared library.
+        #
+        # Note that this is potentially inefficient when a target uses fully
+        # shared linking and depends on multiple Haskell libraries that
+        # have shared CC dependencies. In that situation each Haskell library
+        # will bundle its own copy of the CC dependency.
+        #
+        # We could achieve the same by doing the parsing of LibraryToLink
+        # dependencies here and trying to link as many of them as static
+        # libs, but this would unnecessarily replicate the CC toolchain logic
+        # that we use here.
+        cc_deps_lib_path = "{}/lib{}-cc-deps.so".format(
+            package.libdir(ctx),
+            archive_name,
+        )
+        cc_deps_lib = dynamic_cc_deps_archive(
+            ctx,
+            toolchains.cc,
+            cc_deps_lib_path,
+            collected_deps.immediate_cc_libs,
+        )
+        libs_to_link = [cc_deps_lib.dynamic_library]
+    else:
+        libs_to_link = collected_deps.immediate_cc_dylibs
+        cc_deps_lib = None
+
     package_link = package.link_options(collected_deps)
     options = (
         ghc_options.library_root(config) +
@@ -143,7 +177,7 @@ def create_shared_haskell_lib(ctx, toolchains, archive_name, lib, collected_deps
         ["-shared", "-dynamic", "-o", shared_lib.path] +
         ["-optl" + a for a in _shared_linker_args(
             shared_lib,
-            collected_deps.immediate_cc_dylibs,
+            libs_to_link,
             get_dynamic_runtime_libs(ctx),
         )]
     )
@@ -155,7 +189,7 @@ def create_shared_haskell_lib(ctx, toolchains, archive_name, lib, collected_deps
         arguments = options,
         inputs = depset(
             config.compiler_bundle + [config.compiler, lib.object] +
-            collected_deps.immediate_cc_dylibs,
+            libs_to_link,
             transitive = [
                 package_link.inputs,
                 collected_deps.transitive.haskell.shared_libs,
@@ -168,7 +202,69 @@ def create_shared_haskell_lib(ctx, toolchains, archive_name, lib, collected_deps
         progress_message = "Linking Haskell shared library for " + str(ctx.label),
     )
 
-    return shared_lib
+    return shared_lib, cc_deps_lib
+
+def dynamic_cc_deps_archive(ctx, cc_toolchain, lib_path, libs):
+    """(Mostly) Statically link the specified cc libraries into a shared library.
+
+    This weird trick hardens the Haskell shared libraries, making it possible to
+    use them in targets that use mostly static linking. Without it, blaze is happy
+    to link the cc dependencies directly into the output and consider them resolved,
+    without realizing that the Haskell .so files will need a shared version of them.
+    This helper bundles all cc libraries in a shared object, and hides the possibility
+    of creating its static version from blaze, guaranteeing that the cc deps are always
+    available to be dynamically loaded.
+
+    Args:
+      ctx: The current rule context.
+      cc_toolchain: A struct as returned by get_configured_cc_toolchain.
+      lib_path: The desired path of the output file.
+      libs: A list of LibraryToLink objects representing the cc dependencies.
+
+    Returns:
+      A LibraryToLink, wrapping a shared library that links against all of the libs.
+    """
+
+    # Point the linker at the directories containing the dependencies.
+    # Also include the runtime libraries, which are implicit dependencies of every cc_library.
+    linking_ctx = cc_common.create_linking_context(
+        libraries_to_link = libs,
+    )
+    lib_name = paths.basename(lib_path)
+
+    # Note that even though the output of .link can be used as a static
+    # library, we consciously fail to report that such a static library
+    # can be treated as an output of this rule, to ensure that this
+    # .so will be added to the runfiles.
+    linking_outputs = cc_common.link(
+        actions = ctx.actions,
+        feature_configuration = cc_toolchain.feature_configuration,
+        cc_toolchain = cc_toolchain.toolchain,
+        output_type = "dynamic_library",
+        link_deps_statically = True,
+        linking_contexts = [linking_ctx],
+        name = lib_name,
+    )
+
+    # We have to copy this out, because cc_common.link returns a file in _solib
+    # which triggers an assertion in create_library_to_link.
+    linked_lib = linking_outputs.library_to_link.dynamic_library
+    output_lib = ctx.actions.declare_file(lib_path)
+    ctx.actions.run_shell(
+        inputs = [linked_lib],
+        outputs = [output_lib],
+        command = "cp -f \"$1\" \"$2\"",
+        arguments = [linked_lib.path, output_lib.path],
+        mnemonic = "HaskellCopyCcDeps",
+        progress_message = "Copying CC dependency bundle for Haskell rule " + str(ctx.label),
+        use_default_shell_env = True,
+    )
+    return cc_common.create_library_to_link(
+        actions = ctx.actions,
+        feature_configuration = cc_toolchain.feature_configuration,
+        cc_toolchain = cc_toolchain.toolchain,
+        dynamic_library = output_lib,
+    )
 
 def create_wrapper_shared_cc_lib(ctx, cc_toolchain, name, libs):
     """Links the given shared libraries into another "wrapper" library.

--- a/bzl/private/providers.bzl
+++ b/bzl/private/providers.bzl
@@ -200,6 +200,8 @@ def collect_deps(dependencies):
           be needed by CPP.
         cpp_flags: Flags for running CPP in order to use the cc_headers when
           building the current rule.
+        immediate_cc_libs: A list of LibraryToLink objects of cc_library
+          rules that this target depends directly on.
         immediate_cc_dylibs: A list of Files of ".so" files for the cc_library
           rules that this target depends directly on.
         immediate_module_names_ok: A list of (empty) Files signifying that the
@@ -309,6 +311,8 @@ def collect_deps(dependencies):
         ),
         cc_headers = depset(transitive = [dep.compilation_context.headers for dep in cc_deps]),
         cpp_flags = [flag for dep in cc_deps for flag in get_compile_flags(dep)],
+        immediate_cc_libs = collections.uniq(immediate_cc_libs),
+        only_transitive_cc_libs = depset(transitive = [dep.transitive.cc.libs for dep in all_haskell]),
         immediate_cc_dylibs = collections.uniq(immediate_cc_dylibs),
         immediate_module_names_ok =
             [dep.module_names_ok for dep in all_haskell if dep.module_names_ok],
@@ -397,7 +401,7 @@ def get_dependencies(ctx):
     """
     return struct(
         deps = ctx.attr.deps,
-        plugins = ctx.attr.plugins,
+        plugins = getattr(ctx.attr, "plugins", []),
         default_deps = getattr(ctx.attr, "default_packages", []),
         faked_builddata_libs = builddata.get_faked_globals_libs(ctx),
     )

--- a/bzl/tests/dep_on_haskell/BUILD
+++ b/bzl/tests/dep_on_haskell/BUILD
@@ -9,6 +9,7 @@ haskell_library(
         "Lib.hs",
         "Sub/Lib.hs",
     ],
+    features = ["-parse_headers"],
     foreign_exports = [
         "Lib",
         "Sub.Lib",
@@ -36,6 +37,7 @@ cc_library(
 haskell_library(
     name = "CDep",
     srcs = ["CDep.hs"],
+    features = ["-parse_headers"],
     foreign_exports = [
         "CDep",
     ],

--- a/bzl/tests/dep_on_haskell/BUILD
+++ b/bzl/tests/dep_on_haskell/BUILD
@@ -1,6 +1,6 @@
 # Test that C++ can depend on Haskell.
 
-load("//bzl:def.bzl", "haskell_library")
+load("//bzl:def.bzl", "haskell_library", "haskell_static_foreign_library")
 
 haskell_library(
     name = "Lib",
@@ -14,9 +14,9 @@ haskell_library(
         "Lib",
         "Sub.Lib",
     ],
+    deps = ["//third_party/haskell/text"],
 )
 
-# A C++ binary than depends on a Haskell library.
 cc_test(
     name = "test",
     size = "small",
@@ -25,6 +25,24 @@ cc_test(
     features = ["-layering_check"],
     deps = [
         ":Lib",
+        "//third_party/haskell/ghc:headers",
+    ],
+)
+
+haskell_static_foreign_library(
+    name = "Lib-static",
+    library = ":Lib",
+)
+
+# Make sure that static linking works too.
+cc_test(
+    name = "test-static",
+    srcs = ["test.cc"],
+    # TODO(b/144594873): Don't require this.
+    features = ["-layering_check"],
+    linkstatic = True,
+    deps = [
+        ":Lib-static",
         "//third_party/haskell/ghc:headers",
     ],
 )

--- a/bzl/tests/dep_on_haskell/Lib.hs
+++ b/bzl/tests/dep_on_haskell/Lib.hs
@@ -17,8 +17,13 @@
 module Lib where
 
 import Internal.Inc (inc)
+import Data.Text as T
 
 inc2 :: Int -> Int
 inc2 = inc . inc
 
+mul10 :: Int -> Int
+mul10 = read . T.unpack . (`T.snoc` '0') . T.pack . show
+
 foreign export ccall inc2 :: Int -> Int
+foreign export ccall mul10 :: Int -> Int

--- a/bzl/tests/dep_on_haskell/test.cc
+++ b/bzl/tests/dep_on_haskell/test.cc
@@ -8,6 +8,7 @@ int main(int argc, char **argv) {
   hs_init(&argc, &argv);
   std::cout << inc2(1) << "\n";
   std::cout << inc3(1) << "\n";
+  std::cout << mul10(123) << "\n";
   hs_exit();
   return 0;
 }


### PR DESCRIPTION
**This PR is incomplete!** I've only updated the files that were necessary to apply my patch (in the latest commit) without bringing the rest of the repo up-to-date. As such it will probably break horribly if anyone tried to run it here, but it should be good enough for a review.

Previously, only cc targets that were linked _without_ the linkstatic setting
could depend on the Haskell libraries with foreign exports. Any attempt to
use them in a statically-linked target resulted in a "missing shared object"
error at runtime. The dep_on_haskell cc_tests are linked in shared mode (blaze
default for cc_test), but changing the targets to cc_binary is sufficient to
reproduce the failure.

The CL enables linking of Haskell libraries into static targets and adds a
respective test. The main trick is to avoid linking against shared objects
of cc deps directly when calling GHC to emit the Haskell .so, but instead
link all of them _statically_ into a shared library (which blaze is explicitly
disallowed from compiling as a static library), and make the Haskell target
depend on that. This solves the problem of blaze thinking that it's ok to
simply link all the cc deps directly into the final executable, because every
Haskell .so is accompanied by a self-contained cc shared object.

This of course can introduce some inefficiency when multiple Haskell libs have
common cc dependencies. In that case, the dependencies will get compiled into
each library's private copy of the cc deps. Worse still, linking multiple copies
of a single library statically into a single process might result in some surprises
(e.g. Google flag libraries expect to only be linked in once). Due to that, this
setting is off by default, and can be explicitly opt into by wrapping a Haskell
library in `haskell_static_foreign_library`. This will create an alternative
name for the original library that can only be referenced from targets that expect
the CcInfo provider which will be similar to the one returned by the original target,
with the exception of all cc deps being compiled into self-contained bundles as
described above.